### PR TITLE
Included fourth RPC provider in lesson

### DIFF
--- a/lessons/fundamentals/connect-with-rpc.mdx
+++ b/lessons/fundamentals/connect-with-rpc.mdx
@@ -13,7 +13,7 @@ can be executed on servers remotely. In plain English, an RPC call is how a dApp
 communicates with the blockchain or accesses other information from remote
 servers. In this section, we will concern ourselves with RPC calls to the
 blockchain via _Metamask_ to Ethereum testnets such as _Rinkeby_ and RPC
-endpoint providers such as _Infura_, _Alchemy_ and _Ankr_.
+endpoint providers such as _Infura_, _Alchemy_, _Chainstack_, and _Ankr_.
 
 ### Connecting to a Testnet with Metamask
 
@@ -42,17 +42,19 @@ tutorial or other source.
 In blockchain development, it is necessary to connect your dApp to the
 blockchain to deploy smart contracts and interact with the deployed contract.
 This can be done by either running your own blockchain node such as GETH or
-accessing the blockchain through an RPC endpoint service such as Infura, Alchemy
-or Ankr. Connecting through the 3 providers is much easier than running your own
-node. With all 3 services, it is quick, easy and **FREE** to open an account and
-get access to RPC endpoints of many different testnets including Goerli
+accessing the blockchain through an RPC endpoint service such as Infura, Alchemy, 
+Chainstack, or Ankr. Connecting through the 4 providers is much easier than running 
+your own node. With all 4 services, it is quick, easy and **FREE** to open an account 
+and get access to RPC endpoints of many different testnets including Goerli
 Ethereum, Polygon Mumbai, Optimism Kovan and Solana Devnet. The websites for the
-3 RPC endpoint providers can be found below:
+4 RPC endpoint providers can be found below:
 
 - **Infura**: [**https://infura.io/**](https://infura.io/) Click on the **SIGN
   UP** button.
 - **Alchemy**: [**https://www.alchemy.com/**](https://www.alchemy.com/) Click on
   **Login**, then **Signup** under the Login button.
+- **Chainstack**: [**https://www.chainstack.com/**](https://www.chainstack.com/) 
+  Click on the **Start for free** button.
 - **Ankr**: [**https://www.ankr.com/**](https://www.ankr.com/) Click on **Get a
   free endpoint**, the **Connect wallet** to connect your Metamask wallet.
 

--- a/lessons/fundamentals/connect-with-rpc.mdx
+++ b/lessons/fundamentals/connect-with-rpc.mdx
@@ -43,11 +43,11 @@ In blockchain development, it is necessary to connect your dApp to the
 blockchain to deploy smart contracts and interact with the deployed contract.
 This can be done by either running your own blockchain node such as GETH or
 accessing the blockchain through an RPC endpoint service such as Infura, Alchemy, 
-Chainstack, or Ankr. Connecting through the 4 providers is much easier than running 
-your own node. With all 4 services, it is quick, easy and **FREE** to open an account 
+Chainstack, Ankr, etc. Connecting through node providers is much easier than running 
+your own node. By using a node provider, it is quick, easy and **FREE** to open an account 
 and get access to RPC endpoints of many different testnets including Goerli
 Ethereum, Polygon Mumbai, Optimism Kovan and Solana Devnet. The websites for the
-4 RPC endpoint providers can be found below:
+aforementioned RPC endpoint providers can be found below:
 
 - **Infura**: [**https://infura.io/**](https://infura.io/) Click on the **SIGN
   UP** button.


### PR DESCRIPTION
This lesson previously only included Infura, Alchemy, and Ankr. Chainstack has been included as a fourth provider option for developers to explore.