### PR TITLE
Add an initial documentation section

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -37,15 +37,8 @@ export default function Footer() {
               Feedback
             </Link>
           </NextLink>
-          <NextLink
-            href={
-              'https://github.com/Developer-DAO/academy/blob/main/CONTRIBUTING.md'
-            }
-            passHref
-          >
-            <Link isExternal textDecoration="underline">
-              Contribute
-            </Link>
+          <NextLink href={'/docs'} passHref>
+            <Link textDecoration="underline">Contribute</Link>
           </NextLink>
         </Stack>
         <Stack direction={'row'} spacing={6}>

--- a/pages/docs/content.mdx
+++ b/pages/docs/content.mdx
@@ -1,0 +1,5 @@
+# Documentation
+
+## How to Contribute Content
+
+Process...

--- a/pages/docs/content.mdx
+++ b/pages/docs/content.mdx
@@ -1,5 +1,3 @@
-# Documentation
+# Process for Authoring and Reviewing Content
 
-## How to Contribute Content
-
-Process...
+**Coming Soon**

--- a/pages/docs/day-to-day.mdx
+++ b/pages/docs/day-to-day.mdx
@@ -1,0 +1,3 @@
+# Find and Manage Day-to-Day Project Tasks
+
+**Coming Soon**

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -1,0 +1,9 @@
+# Documentation Home
+
+## How to Contribute
+
+Documentation for contributing code and content to this project.
+
+[How to contribute code](https://github.com/Developer-DAO/academy/blob/main/CONTRIBUTING.md)
+
+[How to contribute content](/docs/content)

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -1,9 +1,13 @@
-# Documentation Home
+# Contributor Docs
 
-## How to Contribute
+Our Academy website and all lesson content are in GitHub.
 
-Documentation for contributing code and content to this project.
+Please visit our
+[contributing doc on GitHub](https://github.com/Developer-DAO/academy/blob/main/CONTRIBUTING.md)
+to get started.
 
-[How to contribute code](https://github.com/Developer-DAO/academy/blob/main/CONTRIBUTING.md)
+## FAQs
 
-[How to contribute content](/docs/content)
+- [How do I find and manage day-to-day project tasks?](/docs/day-to-day)
+- [How do I author content? What is the review process?](/docs/content)
+- [How do I sponsor content?](/docs/sponsor)

--- a/pages/docs/sponsor.mdx
+++ b/pages/docs/sponsor.mdx
@@ -1,0 +1,3 @@
+# Sponsoring Content
+
+**Coming Soon**


### PR DESCRIPTION
## Overview

The goal is to start moving our contribution and process information to the Academy site.

Here's a start to get us rolling.

- the `Contribute` link in the footer points to the new documentation section.
- the links are under the `/docs` route

<img width="675" alt="Screen Shot 2022-10-22 at 11 22 55 AM" src="https://user-images.githubusercontent.com/139330/197356835-8c114be8-7387-48fa-9104-0ccee9834058.png">
