### PR TITLE
styling: side drawer button

### DIFF
--- a/components/mdx/SideDrawer.tsx
+++ b/components/mdx/SideDrawer.tsx
@@ -24,13 +24,12 @@ function SideDrawer(props: any) {
         onClick={onOpen}
         aria-label="Open Drawer"
         variant="ghost"
-        fontSize="xl"
+        fontSize="0.85rem"
         fontWeight="bold"
         bg="gray.700"
         mt="1em"
         height={[`${buttonText.length > 30 ? '3.75rem' : '2.5rem'}`, '2.5rem']}
         style={{
-          whiteSpace: 'normal',
           wordWrap: 'break-word',
         }}
         rightIcon={<ArrowRightIcon />}


### PR DESCRIPTION
<!-- Description of PR... -->
Fix the side drawer button on smaller screen devices e.g iPhone12

## Changes
- Removed `white-space`
- Adjusted `font-size` to 0.85rem

### New Features *(required)*

`Fixes #141`
Will close issue #141 on merge

