### PR TITLE
Move getting started assets to Arweave

### DIFF
--- a/pages/getting-started/index.tsx
+++ b/pages/getting-started/index.tsx
@@ -188,7 +188,7 @@ const GettingStarted: React.FC<LessonProps> = ({ lessons }) => {
           </Heading>
           <Box alignSelf="center">
             <Image
-              src="/assets/getting-started/img_1.png"
+              src="https://arweave.net/hH9yIZMBsV8uY1ep5p9CY4OGUGizGUhv1u_lqLrak_Y"
               alt="highlights of resources"
               w="40em"
             />
@@ -206,7 +206,7 @@ const GettingStarted: React.FC<LessonProps> = ({ lessons }) => {
           </Heading>
           <Box alignSelf="center" pb="1.25rem">
             <Image
-              src="/assets/getting-started/img_2.png"
+              src="https://arweave.net/2f63b009-f3d6-47d4-8c33-8c9f0c0b443a"
               alt="3 month roadmap"
               w="40em"
               borderRadius="0.875rem"


### PR DESCRIPTION
## Changes

- Add assets to ArDrive: https://app.ardrive.io/#/drives/f7615c40-343c-45f5-a883-f32593a0f832?name=D_D+Academy+Lessons+Assets
- Changed links for assets on getting started page from internal asset links to arweave urls

Closes #175 
