### PR TITLE
Add Privacy Policy link. Fix footer layout.

### DIFF
--- a/components/footer/Footer.tsx
+++ b/components/footer/Footer.tsx
@@ -18,14 +18,13 @@ export default function Footer() {
     >
       <Container
         as={Stack}
-        maxW={'6xl'}
+        maxW={'2xl'}
         py={4}
         direction={{ base: 'column', md: 'row' }}
         spacing={4}
         justify={{ base: 'center', md: 'space-between' }}
         align={{ base: 'center', md: 'center' }}
       >
-        <Text>Developer DAO Foundation © {new Date().getFullYear()}</Text>
         <Stack direction={'row'} spacing={3}>
           <NextLink
             href={
@@ -58,6 +57,7 @@ export default function Footer() {
       </Container>
 
       <Container maxW={'6xl'} py={4} centerContent>
+        <Text>Developer DAO Foundation © {new Date().getFullYear()}</Text>
         <Text align="center">
           Website content licensed under{' '}
           <NextLink
@@ -81,6 +81,16 @@ export default function Footer() {
             </Link>
           </NextLink>
           .
+        </Text>
+        <Text>
+          <NextLink
+            href={'https://www.developerdao.com/privacy-policy'}
+            passHref
+          >
+            <Link isExternal textDecoration="underline">
+              Privacy Policy
+            </Link>
+          </NextLink>
         </Text>
       </Container>
     </Box>


### PR DESCRIPTION
- Add Privacy Policy link
- Footer layout looked weird with two rows that had different centering.  Move Copyright line into second row.

Footer before:

<img width="769" alt="Screenshot 2023-02-07 at 7 09 50 PM" src="https://user-images.githubusercontent.com/139330/217419532-f1923674-b41b-4e0d-ba2a-5c57b4bfeb9c.png">

Footer after:

<img width="754" alt="Screenshot 2023-02-07 at 7 09 16 PM" src="https://user-images.githubusercontent.com/139330/217419544-2925e865-afa7-4344-b53f-83140c323cdd.png">

Closes #137.