### PR TITLE
fix: lesson 1 quiz multiselect answers

### DIFF
--- a/utils/quizzes/quiz-lesson-1.json
+++ b/utils/quizzes/quiz-lesson-1.json
@@ -35,20 +35,15 @@
       "question": "A blockchain:",
       "options": [
         {
-          "answer": "Runs on a global network of nodes that is accessible to anyone"
+          "answer": "Runs on a global network of nodes that is accessible to anyone",
+          "correct": true
         },
         {
           "answer": "Runs on a global network of nodes with permissions needed to access it"
         },
         {
-          "answer": "Uses cryptography to secure existing data on the chain"
-        },
-        {
-          "answer": "A & C",
+          "answer": "Uses cryptography to secure existing data on the chain",
           "correct": true
-        },
-        {
-          "answer": "All of the above"
         }
       ]
     },
@@ -88,7 +83,7 @@
       ]
     },
     {
-      "question": "A smart contract deployed to the Blockchain:",
+      "question": "A smart contract deployed to the blockchain:",
       "options": [
         {
           "answer": "Can be edited without redeployment once you have the owner’s credentials"
@@ -127,22 +122,15 @@
       "question": "How many parameters can we have in an event?",
       "options": [
         {
-          "answer": "A. multiple non-indexed parameters"
+          "answer": "A. multiple non-indexed parameters",
+          "correct": true
         },
         {
-          "answer": "B. three indexed named parameters"
+          "answer": "B. three indexed named parameters",
+          "correct": true
         },
         {
-          "answer": "C. four indexed anonymous parameters"
-        },
-        {
-          "answer": "only A and B"
-        },
-        {
-          "answer": "only B and C"
-        },
-        {
-          "answer": "A, B and C",
+          "answer": "C. four indexed anonymous parameters",
           "correct": true
         }
       ]


### PR DESCRIPTION
### what?

eliminates combination and all-of-the-above choices from the lesson 1 quiz.

### why?

because quiz questions are all multi-select, every question offers permutations of answer combinations or "All of the above". including those as explicit choices creates two "correct" answers - and therefore a bug.

noticed this issue while reviewing an unrelated PR. note: i haven't checked the rest of the lessons or mid-point quizzes for this issue yet. cc/ @elPiablo 