### PR TITLE
Fix typo in banner

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -21,7 +21,7 @@ const Banner = () => {
     >
       <Flex align="center" fontSize="sm">
         <Text fontWeight="medium" maxW={{ base: "32ch", md: "unset" }}>
-          Acamdey V2 is coming soon 👀... Subscribe to our newsletter for
+          Academy V2 is coming soon 👀... Subscribe to our newsletter for
           updates!
         </Text>
         <chakra.a


### PR DESCRIPTION
Issue: There is a typo in the v2 banner
 
Solution: Change "Acamdey" to "Academy"
