### PR TITLE
feat:  Fundamentals: part 2/2: update titles and descriptions of Fundamentals

### DIFF
--- a/src/pages/lessons/fundamentals/cli_lesson.mdx
+++ b/src/pages/lessons/fundamentals/cli_lesson.mdx
@@ -11,8 +11,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Getting Started with the command line interface" 
-    description="Learn the basics of using a console/terminal/shell for Ubuntu, Mac and Windows WSL." 
+    title="Command Line Interface (CLI) Basics: A Beginners Guide" 
+    description="Whether you call your CLI a Linux terminal, Mac console, or Windows command prompt, learn navigation, file handling, and essential commands for efficient development" 
 >
 <LessonHeader title="Navigating in a CLI for beginners" />
 

--- a/src/pages/lessons/fundamentals/code-editors.mdx
+++ b/src/pages/lessons/fundamentals/code-editors.mdx
@@ -10,8 +10,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Code Editors (IDEs)" 
-    description="Popular Code Editors (IDEs)" 
+    title="Top IDEs for Efficient Coding" 
+    description="Find the ultimate programming toolkit - the best integrated development environments with features for efficient, enjoyable coding in various languages" 
 >
 <LessonHeader title="Code Editors (IDEs)" />
 

--- a/src/pages/lessons/fundamentals/connect-with-rpc.mdx
+++ b/src/pages/lessons/fundamentals/connect-with-rpc.mdx
@@ -9,8 +9,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Connect with RPC mini-lesson" 
-    description="Connecting to Networks via RPC." 
+    title="Essential RPC Concepts for dApp Connectivity" 
+    description="Connect dApps to testnets/live blockchains with Web3 wallets and RPC endpoint providers. Learn vital RPC concepts" 
 >
 <LessonHeader title="Connecting to a Network via RPC" />
 

--- a/src/pages/lessons/fundamentals/decentralized-storage.mdx
+++ b/src/pages/lessons/fundamentals/decentralized-storage.mdx
@@ -9,8 +9,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Decentralized Storage" 
-    description="Overview on decentralized storage protocols." 
+    title="Decentralized Storage Protocols" 
+    description="A quick dive into decentralized storage with Arweave and IPFS/Filecoin - innovative protocols for secure and reliable data storage in web3" 
 >
 <LessonHeader title="Decentralized Storage with Arweave and IPFS/Filecoin" />
 

--- a/src/pages/lessons/fundamentals/install-npm.mdx
+++ b/src/pages/lessons/fundamentals/install-npm.mdx
@@ -9,8 +9,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Install NPM Using NVM" 
-    description="Installing NPM Using NVM for WSL2, MacOS and Ubuntu." 
+    title="Package Manager Basics: Installing NPM with NVM" 
+    description="A step-by-step guide for setting up NPM using NVM on Linux, MacOS, and WSL2. Choose your OS and configure Node.js for streamlined development" 
 >
 <LessonHeader title="How to install node.js and npm" />
 

--- a/src/pages/lessons/fundamentals/nft-hosting.mdx
+++ b/src/pages/lessons/fundamentals/nft-hosting.mdx
@@ -10,8 +10,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="NFT Hosting on OpenSea and Rarible" 
-    description="NFT Collections hosted on OpenSea and Rarible" 
+    title="Hosting NFTs on OpenSea & Rarible" 
+    description="What is NFT hosting on OpenSea and Rarible? Learn about showcasing and trading various digital assets in the dynamic world of NFTs" 
 >
 <LessonHeader title="NFT hosting through OpenSea and Rarible" />
 

--- a/src/pages/lessons/fundamentals/open_zeppelin.mdx
+++ b/src/pages/lessons/fundamentals/open_zeppelin.mdx
@@ -9,8 +9,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="OpenZeppelin"
-    description="Overview of OpenZeppelin Contracts."
+    title="Basics of OpenZeppelin Smart Contracts"
+    description="Check out the foundations of OpenZeppelin contracts for robust and secure smart contract development in the web3 ecosystem"
 >
 <LessonHeader title="OpenZeppelin Smart Contract Concepts" />
 

--- a/src/pages/lessons/fundamentals/testnets.mdx
+++ b/src/pages/lessons/fundamentals/testnets.mdx
@@ -9,8 +9,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Testnets mini-lesson" 
-    description="Mini-lesson for Testnets" 
+    title="Testing… test, test, testnets. Why they matter in Web3" 
+    description="Discover the crucial role of testnets in Web3. Developers, understand why and how to fulfill your responsibilities for secure development" 
 >
 <LessonHeader title="Test, test, test, testnets" />
 

--- a/src/pages/lessons/fundamentals/token-standards.mdx
+++ b/src/pages/lessons/fundamentals/token-standards.mdx
@@ -11,8 +11,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="ERC Token Standards" 
-    description="Overview and use cases of ERC tokens." 
+    title="Demystifying (ERC) Token Standards in Web3" 
+    description="What are ERC token standards in Web3? From fungible to NFTs and beyond, explore the Lego-like interoperability of decentralized networks" 
 >
 <LessonHeader title="What are token standards and why do we need them?" />
 

--- a/src/pages/lessons/fundamentals/wallets.mdx
+++ b/src/pages/lessons/fundamentals/wallets.mdx
@@ -10,8 +10,8 @@ import { LessonHeader } from "../../../components/mdx/LessonHeader";
 import Layout from "../../../components/Layout";
 
 <Layout
-    title="Introduction to web3 wallets" 
-    description="Overview of wallet use cases and setting up environment." 
+    title="Understanding Web3 Wallets: A Set up Guide" 
+    description="Delve into Web3 wallet variants and grasp essential concepts, including public and private keys, and security best practices as a developer" 
 >
 <LessonHeader title="Web3 wallets, and public and private keys..." />
 


### PR DESCRIPTION
<!-- Description of PR... -->

- In case you're wondering, I created new PR for exactly the same issue. I needed to change the branch name - now it reflects the PR's intention
- no need to check it really, but if you want to have a look, here is the existing PR for reference: https://github.com/Developer-DAO/academy/pull/275

## Fundamentals part 2/2: SEO friendly update titles and descriptions of Fundamentals

## Changes made **only** in the < Layout > component

- update title
- update descriptions

## Further questions on titles and descriptions:
`piablo` I think it's very messy to have so many different versions of titles and descriptions in different places i.e. in the code and in the actual lesson content. 
- should we also update the front matter with the same titles and descriptions? And will that break the source code? Do we actually still use the front matter (in the same way) in Version 2?
- should we also update the with the same title in the < LessonHeader title= /> component ? And would that break the source code? An idea is that we could still use the concept of **Lesson 1:** Intro......, **Lesson 2:** Build Your...., **Lesson 3:** Create Tiered NFTs...., etc so that it signals the learner's position within a given track.
