### PR TITLE
remove EthIntro type

### DIFF
--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -1,4 +1,4 @@
-import { type Project, type Fundamental, type EthIntro } from "@/interfaces";
+import { type Project, type Fundamental } from "@/interfaces";
 import { createContext, useContext } from "react";
 
 interface IAppContext {

--- a/src/contexts/AppContextProvider.tsx
+++ b/src/contexts/AppContextProvider.tsx
@@ -8,7 +8,6 @@ import { AppContext } from "./AppContext";
 import {
   type Project,
   type Fundamental,
-  type EthIntro,
   type IFormatedLessons,
 } from "@/interfaces";
 import { useSession } from "next-auth/react";

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -43,13 +43,6 @@ export interface Project {
   completed?: boolean;
 }
 
-export interface EthIntro {
-  path: string;
-  frontMatter: ProjectFrontMatter;
-  slug: string;
-  completed?: boolean;
-}
-
 export interface ProjectFrontMatter {
   title: string;
   description: string;

--- a/src/pages/lessons/fundamentals/eth-intro-part-2.mdx
+++ b/src/pages/lessons/fundamentals/eth-intro-part-2.mdx
@@ -273,7 +273,7 @@ import { ContributorFooter } from "../../../components/mdx/ContributorFooter";
 
 <ContributorFooter
   authors={["wolovim"]}
-  reviewers={[]}
+  reviewers={["piablo"]}
   contributors={[]}
 />
 </Layout>

--- a/src/pages/lessons/fundamentals/eth-intro-part-3.mdx
+++ b/src/pages/lessons/fundamentals/eth-intro-part-3.mdx
@@ -183,7 +183,7 @@ import { ContributorFooter } from "../../../components/mdx/ContributorFooter";
 
 <ContributorFooter
   authors={["wolovim"]}
-  reviewers={[]}
+  reviewers={["piablo"]}
   contributors={[]}
 />
 </Layout>


### PR DESCRIPTION
### What does it do?

- fixes an oop. i left an unused type in the intro to ethereum, pt 2 + 3 PR. removing it here.
- edit: adds piablo as reviewer to those two lessons.