### PR TITLE
fix: update outdated links to external resources

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -85,7 +85,7 @@ export default function Footer() {
           Website code is licensed under{" "}
           <Link
             as={NextLink}
-            href={"https://github.com/Developer-DAO/academy/blob/main/LICENSE"}
+            href={"https://github.com/Developer-DAO/academy/blob/main/README.md#what-license-applies-to-this-sites-content-and-code"}
             passHref
             isExternal
             textDecoration="underline"

--- a/src/pages/lessons/fundamentals/code-editors.mdx
+++ b/src/pages/lessons/fundamentals/code-editors.mdx
@@ -69,9 +69,9 @@ To help you make an informed decision, check for the following features:
   added bells and whistles to Window's Notepad. Some of the features are Syntax
   Highlighting and Syntax Folding, auto-completion: Word completion, Function
   completion and Function parameters hint, Multi-Document (Tab interface) and
-  supports several languages. You can find a list
-  of [Notepad++ plugins](http://docs.notepad-plus-plus.org/index.php?title=Plugin_Central)
-  at Wiki.
+  supports several languages. Available Notepad++ [plugins](https://notepad-plus-plus.org/resources/#plugins)
+  can be found in [community list](https://github.com/notepad-plus-plus/nppPluginList?tab=readme-ov-file)
+  at Github.
 
 ![IDE-VS Code](/assets/lessons/code-editors/IDE-notepad-2plus.png)
 

--- a/src/pages/lessons/projects/2.mdx
+++ b/src/pages/lessons/projects/2.mdx
@@ -891,7 +891,7 @@ In order to deploy to a real testnet we'll need:
   [Metamask](https://metamask.io/) is often used
 - Some Sepolia-ETH. You can ask for some in a faucet, it's free, although some
   are faster than others! Options: [#1](https://sepoliafaucet.com/),
-  [#2](https://testnet-faucet.com/sepolia/),
+  [#2](https://sepolia-faucet.pk910.de/),
   [#3](https://faucet.quicknode.com/ethereum/sepolia)
 - An API Key from an Ethereum RPC Node Provider
   ([Alchemy](https://www.alchemy.com/), [Infura](https://infura.io/),

--- a/src/pages/lessons/projects/6.mdx
+++ b/src/pages/lessons/projects/6.mdx
@@ -658,7 +658,7 @@ transaction to deploy our contract. If you already have some Test ETH in
 Sepolia, you can continue, if you don't you can always ask for some in the many
 faucets that are online. Some options are:
 [Alchemy](https://sepoliafaucet.com/),
-[Sepolia Faucet](https://testnet-faucet.com/sepolia/) or
+[Sepolia Faucet](https://sepolia-faucet.pk910.de/) or
 [Quicknode](https://faucet.quicknode.com/ethereum/sepolia), but you can find
 more if you search for Sepolia Faucet in any search engine.
 


### PR DESCRIPTION
Hello,
I've found some outdated links to external resources, I'm replacing all outdated links with working ones. 

## Changes

Namely it is:
- Sepolia faucet replaced by PoW Faucet (best always working faucet I know).
- Notepad++ plugin list (moved from N++ webpage into Github repo).
- Academy footer link to DeveloperDao license.

### New Features *(required)*

No new features.
