### PR TITLE
# Fix Typo in `env.mjs`

### DIFF
--- a/src/env.mjs
+++ b/src/env.mjs
@@ -16,7 +16,7 @@ const server = z.object({
     // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
     // Since NextAuth.js automatically uses the VERCEL_URL if present.
     (str) => process.env.VERCEL_URL ?? str,
-    // VERCEL_URL doesn't include `https` so it cant be validated as a URL
+    // VERCEL_URL doesn't include `https` so it can't be validated as a URL
     process.env.VERCEL ? z.string().min(1) : z.string().url(),
   ),
   // Add `.min(1) on ID and SECRET if you want to make sure they're not empty


### PR DESCRIPTION
# Fix Typo in `env.mjs`

## Description
This pull request resolves a typo in a comment within the `env.mjs` file to ensure clarity and accuracy in the documentation.

### Changes Made:
- **File Modified:** `src/env.mjs`
- **Summary of Changes:**
  - Line 16: Corrected "cant" to "can't."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [Contributing Guidelines](link-to-guidelines), [Security Policy](link-to-security-policy), and [Code of Conduct](link-to-code-of-conduct).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update is a non-functional change and is strictly related to improving the readability of the comments.

---

**Allow edits by maintainers:** [x]  
<!-- Check this box to allow maintainers to modify the pull request if needed. -->
